### PR TITLE
FIX: Use circular-json to handle circular references (fix #5)

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,8 +1,10 @@
 var path = require( 'path' );
 var fs = require( 'graceful-fs' );
-var readJSON = require( 'read-json-sync' );
 var write = require( 'write' );
 var del = require( 'del' ).sync;
+var circularJson = require( 'circular-json' );
+
+var fileCache = { };
 
 var cache = {
   /**
@@ -22,7 +24,8 @@ var cache = {
     me._pathToFile = cacheDir ? path.resolve( cacheDir, docId ) : path.resolve( __dirname, './.cache/', docId );
 
     if ( fs.existsSync( me._pathToFile ) ) {
-      me._persisted = readJSON( me._pathToFile );
+      me._persisted = fileCache[ me._pathToFile ] || circularJson.parse( fs.readFileSync( me._pathToFile ).toString() );
+      fileCache[ me._pathToFile ] = me._persisted;
     }
   },
 
@@ -106,7 +109,7 @@ var cache = {
     var me = this;
 
     me._prune();
-    write.sync( me._pathToFile, JSON.stringify( me._persisted ) );
+    write.sync( me._pathToFile, circularJson.stringify( me._persisted ) );
   },
 
   /**

--- a/cache.js
+++ b/cache.js
@@ -1,10 +1,8 @@
 var path = require( 'path' );
 var fs = require( 'graceful-fs' );
-var write = require( 'write' );
 var del = require( 'del' ).sync;
-var circularJson = require( 'circular-json' );
-
-var fileCache = { };
+var readJSON = require( './utils' ).readJSON;
+var writeJSON = require( './utils' ).writeJSON;
 
 var cache = {
   /**
@@ -24,8 +22,7 @@ var cache = {
     me._pathToFile = cacheDir ? path.resolve( cacheDir, docId ) : path.resolve( __dirname, './.cache/', docId );
 
     if ( fs.existsSync( me._pathToFile ) ) {
-      me._persisted = fileCache[ me._pathToFile ] || circularJson.parse( fs.readFileSync( me._pathToFile ).toString() );
-      fileCache[ me._pathToFile ] = me._persisted;
+      me._persisted = readJSON( me._pathToFile );
     }
   },
 
@@ -109,7 +106,7 @@ var cache = {
     var me = this;
 
     me._prune();
-    write.sync( me._pathToFile, circularJson.stringify( me._persisted ) );
+    writeJSON( me._pathToFile, me._persisted );
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "watch-run": "^1.2.2"
   },
   "dependencies": {
+    "circular-json": "^0.3.0",
     "del": "^2.0.2",
     "graceful-fs": "^4.1.2",
     "read-json-sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "beautify": "esbeautifier 'cache.js' 'specs/**/*.js'",
     "beautify-check": "npm run beautify -- -k",
-    "eslint": "eslinter 'cache.js' 'specs/**/*.js'",
+    "eslint": "eslinter 'cache.js' 'utils.js' 'specs/**/*.js'",
     "eslint-fix": "npm run eslint -- --fix",
     "autofix": "npm run beautify && npm run eslint-fix",
     "check": "npm run beautify-check && npm run eslint",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "circular-json": "^0.3.0",
     "del": "^2.0.2",
     "graceful-fs": "^4.1.2",
-    "read-json-sync": "^1.1.0",
     "write": "^0.2.1"
   }
 }

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -1,7 +1,7 @@
 describe( 'flat-cache', function () {
   'use strict';
   var expect = require( 'chai' ).expect;
-  var readJSON = require( 'read-json-sync' );
+  var readJSON = require( '../../utils.js' ).readJSON;
   var path = require( 'path' );
   var del = require( 'del' ).sync;
   var fs = require( 'fs' );
@@ -220,6 +220,22 @@ describe( 'flat-cache', function () {
 
       expect( fs.existsSync( file ) ).to.be.false;
     } );
+  } );
+
+  it( 'should serialize and deserialize properly circular reference', function () {
+    var cache = flatCache.load( 'someId' );
+    var data = {
+      foo: 'foo',
+      bar: 'bar'
+    };
+
+    data.circular = data
+
+    cache.setKey( 'some-key', data );
+    expect( cache.getKey( 'some-key' ) ).to.deep.equal( data );
+
+    cache.save();
+    expect( readJSON( path.resolve( __dirname, '../../.cache/someId' ) )[ 'some-key' ] ).to.deep.equal( data );
   } );
 
 } );

--- a/utils.js
+++ b/utils.js
@@ -12,7 +12,7 @@ module.exports = {
    * @returns {*} parse result
    */
   readJSON: function ( filePath ) {
-    return circularJson.parse( fs.readFileSync( filePath ).toString().replace(/^\ufeff/g, '') );
+    return circularJson.parse( fs.readFileSync( filePath ).toString() );
   },
 
   /**

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,6 @@
 var fs = require( 'graceful-fs' );
 var write = require( 'write' );
-var circularJson = require( 'circular-json' )
+var circularJson = require( 'circular-json' );
 
 module.exports = {
 

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,29 @@
+var fs = require( 'graceful-fs' );
+var write = require( 'write' );
+var circularJson = require( 'circular-json' )
+
+module.exports = {
+
+  /**
+   * Read json file synchronously using circular-json
+   *
+   * @method readJSON
+   * @param  {String} filePath Json filepath
+   * @returns {*} parse result
+   */
+  readJSON: function ( filePath ) {
+    return circularJson.parse( fs.readFileSync( filePath ).toString().replace(/^\ufeff/g, '') );
+  },
+
+  /**
+   * Write json file synchronously using circular-json
+   *
+   * @method writeJSON
+   * @param  {String} filePath Json filepath
+   * @param  {*} data Object to serialize
+   */
+  writeJSON: function (filePath, data ) {
+    write.sync( filePath, circularJson.stringify( data ) );
+  }
+
+};


### PR DESCRIPTION
Ok, I found that the problem illustrated in #5 is not related to circular dependency in js module. The real reason is the use of the `browserify.transform` option field in a node package when used with watchify (circular reference with `packageCache`).

I made a small project to illustrate the issue: https://github.com/nopnop/fix-circular-flatcache

Using the suggested https://github.com/WebReflection/circular-json for both serializing and deserializing fix the issue nicely.

The test passes: yet I'm not sure how to handle this special case of Circular Reference in the test suite.

The stateful `fileCache` variable I've added is used to reproduce the caching mechanism of the removed `read-json-sync` package