### PR TITLE
Bumping `circular-json` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "watch-run": "^1.2.2"
   },
   "dependencies": {
-    "circular-json": "^0.3.0",
+    "circular-json": "^0.3.1",
     "del": "^2.0.2",
     "graceful-fs": "^4.1.2",
     "write": "^0.2.1"


### PR DESCRIPTION
As mentioned in https://github.com/WebReflection/circular-json/issues/25 `circular-json` wan't rightly implementing the license field.

Latest version bump changed only that bit so that ESLint should now be happy.