### PR TITLE
FIX: Do not crash if cache file is invalid JSON.

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,8 +1,8 @@
 var path = require( 'path' );
 var fs = require( 'graceful-fs' );
 var del = require( 'del' ).sync;
-var readJSON = require( './utils' ).readJSON;
-var writeJSON = require( './utils' ).writeJSON;
+var utils = require( './utils' );
+var writeJSON = utils.writeJSON;
 
 var cache = {
   /**
@@ -22,7 +22,7 @@ var cache = {
     me._pathToFile = cacheDir ? path.resolve( cacheDir, docId ) : path.resolve( __dirname, './.cache/', docId );
 
     if ( fs.existsSync( me._pathToFile ) ) {
-      me._persisted = readJSON( me._pathToFile );
+      me._persisted = utils.tryParse( me._pathToFile, { } );
     }
   },
 

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -6,6 +6,7 @@ describe( 'flat-cache', function () {
   var del = require( 'del' ).sync;
   var fs = require( 'fs' );
   var flatCache = require( '../../cache' );
+  var write = require( 'write' );
 
   beforeEach( function () {
     flatCache.clearAll();
@@ -18,6 +19,27 @@ describe( 'flat-cache', function () {
     del( path.resolve( __dirname, '../fixtures/.cache/' ), { force: true } );
     del( path.resolve( __dirname, '../fixtures/.cache2/' ), { force: true } );
   } );
+
+  it( 'should not crash if the cache file exists but it is an empty string', function () {
+    var cachePath = path.resolve( __dirname, '../fixtures/.cache2' );
+    write.sync( path.join( cachePath, 'someId' ), '' );
+
+    expect( function () {
+      var cache = flatCache.load( 'someId', cachePath );
+      expect( cache._persisted ).to.deep.equal( { } );
+    } ).to.not.throw( Error )
+  } );
+
+  it( 'should not crash if the cache file exists but it is an invalid JSON string', function () {
+    var cachePath = path.resolve( __dirname, '../fixtures/.cache2' );
+    write.sync( path.join( cachePath, 'someId' ), '{ "foo": "fookey", "bar" ' );
+
+    expect( function () {
+      var cache = flatCache.load( 'someId', cachePath );
+      expect( cache._persisted ).to.deep.equal( { } );
+    } ).to.not.throw( Error )
+  } );
+
 
   it( 'should create a cache object if none existed in disc with the given id', function () {
     var cache = flatCache.load( 'someId' );

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,16 @@ var circularJson = require( 'circular-json' );
 
 module.exports = {
 
+  tryParse: function ( filePath, defaultValue) {
+    var result;
+    try {
+      result = this.readJSON( filePath );
+    } catch (ex) {
+      result = defaultValue;
+    }
+    return result;
+  },
+
   /**
    * Read json file synchronously using circular-json
    *


### PR DESCRIPTION
Fixes #12

Not sure under which situations a cache file might exist that does
not contain a valid JSON structure, but just in case to cover
the possibility of this happening a try catch block has been added

If the cache is somehow not valid the cache will be discarded an a
a new cache will be stored instead