### PR TITLE
Removed the need for del

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,7 +1,7 @@
 var path = require( 'path' );
 var fs = require( 'graceful-fs' );
-var del = require( 'del' ).sync;
 var utils = require( './utils' );
+var rimraf = require( 'rimraf' ).sync;
 var writeJSON = utils.writeJSON;
 
 var cache = {
@@ -125,9 +125,8 @@ var cache = {
    * @return {Boolean} true or false if the file was successfully deleted
    */
   removeCacheFile: function () {
-    return del( this._pathToFile, {
-      force: true
-    } );
+    rimraf( this._pathToFile );
+    return !fs.existsSync( this._pathToFile );
   },
   /**
    * Destroy the file cache and cache content.
@@ -185,9 +184,11 @@ module.exports = {
    */
   clearCacheById: function ( docId, cacheDir ) {
     var filePath = cacheDir ? path.resolve( cacheDir, docId ) : path.resolve( __dirname, './.cache/', docId );
-    return del( filePath, {
-        force: true
-      } ).length > 0;
+    if ( !fs.existsSync( filePath ) ) {
+      return false;
+    }
+    rimraf( filePath );
+    return true;
   },
   /**
    * Remove all cache stored in the cache directory
@@ -196,8 +197,10 @@ module.exports = {
    */
   clearAll: function ( cacheDir ) {
     var filePath = cacheDir ? path.resolve( cacheDir ) : path.resolve( __dirname, './.cache/' );
-    return del( filePath, {
-        force: true
-      } ).length > 0;
+    if ( !fs.existsSync( filePath ) ) {
+      return false;
+    }
+    rimraf( filePath );
+    return true;
   }
 };

--- a/cache.js
+++ b/cache.js
@@ -125,8 +125,8 @@ var cache = {
    * @return {Boolean} true or false if the file was successfully deleted
    */
   removeCacheFile: function () {
-    rimraf( this._pathToFile );
-    return !fs.existsSync( this._pathToFile, {glob: false} );
+    rimraf( this._pathToFile, {glob: false} );
+    return !fs.existsSync( this._pathToFile );
   },
   /**
    * Destroy the file cache and cache content.

--- a/cache.js
+++ b/cache.js
@@ -1,7 +1,7 @@
 var path = require( 'path' );
 var fs = require( 'graceful-fs' );
 var utils = require( './utils' );
-var rimraf = require( 'rimraf' ).sync;
+var del = require( './del' );
 var writeJSON = utils.writeJSON;
 
 var cache = {
@@ -125,8 +125,7 @@ var cache = {
    * @return {Boolean} true or false if the file was successfully deleted
    */
   removeCacheFile: function () {
-    rimraf( this._pathToFile, {glob: false} );
-    return !fs.existsSync( this._pathToFile );
+    return del( this._pathToFile );
   },
   /**
    * Destroy the file cache and cache content.
@@ -184,11 +183,7 @@ module.exports = {
    */
   clearCacheById: function ( docId, cacheDir ) {
     var filePath = cacheDir ? path.resolve( cacheDir, docId ) : path.resolve( __dirname, './.cache/', docId );
-    if ( !fs.existsSync( filePath ) ) {
-      return false;
-    }
-    rimraf( filePath, {glob: false} );
-    return true;
+    return del( filePath );
   },
   /**
    * Remove all cache stored in the cache directory
@@ -197,10 +192,6 @@ module.exports = {
    */
   clearAll: function ( cacheDir ) {
     var filePath = cacheDir ? path.resolve( cacheDir ) : path.resolve( __dirname, './.cache/' );
-    if ( !fs.existsSync( filePath ) ) {
-      return false;
-    }
-    rimraf( filePath, {glob: false} );
-    return true;
+    return del( filePath );
   }
 };

--- a/cache.js
+++ b/cache.js
@@ -126,7 +126,7 @@ var cache = {
    */
   removeCacheFile: function () {
     rimraf( this._pathToFile );
-    return !fs.existsSync( this._pathToFile );
+    return !fs.existsSync( this._pathToFile, {glob: false} );
   },
   /**
    * Destroy the file cache and cache content.
@@ -187,7 +187,7 @@ module.exports = {
     if ( !fs.existsSync( filePath ) ) {
       return false;
     }
-    rimraf( filePath );
+    rimraf( filePath, {glob: false} );
     return true;
   },
   /**
@@ -200,7 +200,7 @@ module.exports = {
     if ( !fs.existsSync( filePath ) ) {
       return false;
     }
-    rimraf( filePath );
+    rimraf( filePath, {glob: false} );
     return true;
   }
 };

--- a/del.js
+++ b/del.js
@@ -1,0 +1,11 @@
+var rimraf = require ( 'rimraf' ).sync;
+var fs = require ( 'graceful-fs' );
+
+module.exports = function del (file) {
+    if ( fs.existsSync ( file ) ) {
+            //if rimraf doesn't throw then the file has been deleted or didn't exist
+            rimraf( file, { glob:false });
+            return true;
+    }
+    return false;
+}

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
   },
   "dependencies": {
     "circular-json": "^0.3.1",
-    "del": "^3.0.0",
     "graceful-fs": "^4.1.2",
+    "rimraf": "~2.6.2",
     "write": "^0.2.1"
   }
 }

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -3,29 +3,21 @@ describe( 'flat-cache', function () {
   var expect = require( 'chai' ).expect;
   var readJSON = require( '../../utils.js' ).readJSON;
   var path = require( 'path' );
-  var del = require( 'del' ).sync;
+  var rimraf = require( 'rimraf' ).sync;
   var fs = require( 'fs' );
   var flatCache = require( '../../cache' );
   var write = require( 'write' );
 
   beforeEach( function () {
     flatCache.clearAll();
-    del( path.resolve( __dirname, '../fixtures/.cache/' ), {
-      force: true
-    } );
-    del( path.resolve( __dirname, '../fixtures/.cache2/' ), {
-      force: true
-    } );
+    rimraf( path.resolve( __dirname, '../fixtures/.cache/' ) );
+    rimraf( path.resolve( __dirname, '../fixtures/.cache2/' ) );
   } );
 
   afterEach( function () {
     flatCache.clearAll();
-    del( path.resolve( __dirname, '../fixtures/.cache/' ), {
-      force: true
-    } );
-    del( path.resolve( __dirname, '../fixtures/.cache2/' ), {
-      force: true
-    } );
+    rimraf( path.resolve( __dirname, '../fixtures/.cache/' ) );
+    rimraf( path.resolve( __dirname, '../fixtures/.cache2/' ) );
   } );
 
   it( 'should not crash if the cache file exists but it is an empty string', function () {
@@ -184,9 +176,7 @@ describe( 'flat-cache', function () {
   describe( 'loading a cache using a filePath directly', function () {
     var file = path.resolve( __dirname, '../fixtures/.cache2/mycache-file.cache' );
     beforeEach( function () {
-      del( file, {
-        force: true
-      } );
+      rimraf( file );
     } );
 
     it( 'should create the file if it does not exists before', function () {


### PR DESCRIPTION
Removed the need for del as newer versions have broken backwards
compatibility. del mainly uses rimraf for deleting folders
and files, replaceing it with rimraf only is a minimal change.
Fixes #32 